### PR TITLE
Fix: preserve /updates/ pages from catch-all redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,12 @@
   command = "npm run start"
   
 [[redirects]]
+  from = "/updates/*"
+  to = "/updates/:splat"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "https://luthienresearch.github.io/luthien-pbc-site/"
   status = 301


### PR DESCRIPTION
## Summary
- The catch-all redirect `/* -> luthien-pbc-site` was also redirecting `/updates/*` pages, making blog posts like the 21 Points post unreachable
- Adds an exception for `/updates/*` so those pages render from the Eleventy site as intended

## Test plan
- [ ] Verify https://luthienresearch.org/updates/2025-03-redteam-as-upsampling/ loads the actual post instead of redirecting
- [ ] Verify other pages still redirect to luthien-pbc-site

Generated with [Claude Code](https://claude.com/claude-code)